### PR TITLE
Switches to overwriting the real file

### DIFF
--- a/.github/workflows/run-update.yml
+++ b/.github/workflows/run-update.yml
@@ -49,7 +49,7 @@ jobs:
           export_default_credentials: true
       - name: Copy config file to bucket.
         run: |
-          gsutil cp docker.config gs://helium-assets.nebra.com/test.config
+          gsutil cp docker.config gs://helium-assets.nebra.com/docker.config
       - name: Set ACL
         run: |
-          gsutil acl set acl.txt gs://helium-assets.nebra.com/test.config
+          gsutil acl set acl.txt gs://helium-assets.nebra.com/docker.config


### PR DESCRIPTION
Changes the output file in GCS from `test.config` to `docker.config`.

The last output is as follows:

```
%% -*- erlang -*-
[
  "config/sys.config",
  {lager,
    [
      {log_root, "/var/log/miner"}
    ]},
    {blockchain,
    [
      {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 0}]}},
      {blessed_snapshot_block_height, 920076},
      {blessed_snapshot_block_hash,
      <<106,248,181,242,24,103,177,95,76,128,249,147,22,226,221,67,112,197,218,185,248,196,40,127,90,41,242,163,119,64,17,35>>}
    ]},
  {miner,
    [
      {use_ebus, true},
      {radio_device, { {0,0,0,0}, 1680,
        {0,0,0,0}, 31341} }
    ]}
].% 
```