### PR TITLE
Enable JSON RPC API to listen on all interfaces

### DIFF
--- a/config.template
+++ b/config.template
@@ -90,7 +90,7 @@
   ]},
  {miner,
   [
-   {jsonrpc_ip, {127,0,0,1}}, %% bind JSONRPC to localhost only
+   {jsonrpc_ip, {0,0,0,0}}, %% bind JSONRPC to localhost only
    {jsonrpc_port, 4467},
    {mode, gateway},
    {use_ebus, true},

--- a/miner_config/tests/fixtures/sample_output.txt
+++ b/miner_config/tests/fixtures/sample_output.txt
@@ -90,7 +90,7 @@
   ]},
  {miner,
   [
-   {jsonrpc_ip, {127,0,0,1}}, %% bind JSONRPC to localhost only
+   {jsonrpc_ip, {0,0,0,0}}, %% bind JSONRPC to localhost only
    {jsonrpc_port, 4467},
    {mode, gateway},
    {use_ebus, true},


### PR DESCRIPTION
Enable JSON RPC API to listen on all interfaces, will only be exposed to internal docker network in docker-compose file.  See - https://github.com/NebraLtd/hm-diag/issues/112