### PR TITLE
explicitly checkout production branch

### DIFF
--- a/.github/workflows/run-update-production.yml
+++ b/.github/workflows/run-update-production.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-assets.nebra.com/docker.config
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots.nebra.com/latest.json
+          gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots.nebra.com/latest-snap.json
       - name: Purge Cloudflare Cache for URL
         run: |
           sleep 2m

--- a/.github/workflows/run-update-production.yml
+++ b/.github/workflows/run-update-production.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: production
       - name: Install Python & dependencies.
         run: |
           sudo apt-get update


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Because this is running on a schedule, it might not always check out the production branch implicitly.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

This changes the checkout to be explicitly the production branch

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events
