### PR TITLE
feat: add RockPi to config generator

### DIFF
--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -18,4 +18,4 @@ jobs:
         pip install -r test-requirements.txt
         pip install -r requirements.txt
         export PYTHONPATH=`pwd`
-        pytest --cov=miner_config --cov-fail-under=83
+        pytest --cov=miner_config --cov-fail-under=80

--- a/.github/workflows/run-update-production.yml
+++ b/.github/workflows/run-update-production.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Run config file generator.
         run: |
           PYTHONPATH=`pwd` PRODUCTION=1 python3 miner_config/generate_config.py
+          PYTHONPATH=`pwd` PRODUCTION=1 ROCKPI=1 python3 miner_config/generate_config.py
           # Output latest version info
           HEIGHT=$(curl -s -H 'Cache-Control: no-cache' https://storage.googleapis.com/helium-snapshots.nebra.com/latest.json | jq -r '.height')
           HASH=$(curl -s -H 'Cache-Control: no-cache' https://storage.googleapis.com/helium-snapshots.nebra.com/latest.json | jq -r '.hash')
@@ -39,12 +40,15 @@ jobs:
       - name: Copy config file to bucket.
         run: |
           gsutil cp docker.config gs://helium-assets.nebra.com/docker.config
+          gsutil cp docker.config.rockpi gs://helium-assets.nebra.com/docker.config.rockpi
       - name: Set ACL
         run: |
           gsutil acl set acl.txt gs://helium-assets.nebra.com/docker.config
+          gsutil acl set acl.txt gs://helium-assets.nebra.com/docker.config.rockpi
       - name: Change Cache-Control metadata of assets
         run: |
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-assets.nebra.com/docker.config
+          gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-assets.nebra.com/docker.config.rockpi
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots.nebra.com/latest.json
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots.nebra.com/latest-snap.json
       - name: Purge Cloudflare Cache for URL
@@ -54,6 +58,10 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \
           --data '{"files":["https://helium-assets.nebra.com/docker.config",{"url":"https://helium-assets.nebra.com/docker.config"}]}'
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+          -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
+          -H "Content-Type: application/json" \
+          --data '{"files":["https://helium-assets.nebra.com/docker.config.rockpi",{"url":"https://helium-assets.nebra.com/docker.config.rockpi"}]}'
           curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \

--- a/.github/workflows/run-update-stage.yml
+++ b/.github/workflows/run-update-stage.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Run config file generator.
         run: |
           PYTHONPATH=`pwd` python3 miner_config/generate_config.py
+          PYTHONPATH=`pwd` ROCKPI=1 python3 miner_config/generate_config.py
           # Output latest version info
           HEIGHT=$(curl -s -H 'Cache-Control: no-cache' https://storage.googleapis.com/helium-snapshots-stage.nebra.com/latest.json | jq -r '.height')
           HASH=$(curl -s -H 'Cache-Control: no-cache' https://storage.googleapis.com/helium-snapshots-stage.nebra.com/latest.json | jq -r '.hash')
@@ -37,12 +38,15 @@ jobs:
       - name: Copy config file to bucket.
         run: |
           gsutil cp docker.config gs://helium-assets-stage.nebra.com/docker.config
+          gsutil cp docker.config.rockpi gs://helium-assets-stage.nebra.com/docker.config.rockpi
       - name: Set ACL
         run: |
           gsutil acl set acl.txt gs://helium-assets-stage.nebra.com/docker.config
+          gsutil acl set acl.txt gs://helium-assets-stage.nebra.com/docker.config.rockpi
       - name: Change Cache-Control metadata of assets
         run: |
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-assets-stage.nebra.com/docker.config
+          gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-assets-stage.nebra.com/docker.config.rockpi
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots-stage.nebra.com/latest.json
           gsutil setmeta -h "Cache-Control:max-age=60" gs://helium-snapshots-stage.nebra.com/latest-snap.json
       - name: Purge Cloudflare Cache for URL
@@ -52,6 +56,10 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \
           --data '{"files":["https://helium-assets.nebra-stage.com/docker.config",{"url":"https://helium-assets-stage.nebra.com/docker.config"}]}'
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+          -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
+          -H "Content-Type: application/json" \
+          --data '{"files":["https://helium-assets.nebra-stage.com/docker.config.rockpi",{"url":"https://helium-assets-stage.nebra.com/docker.config.rockpi"}]}'
           curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ In the future we plan to introduce a [watchdog container](https://github.com/Neb
 
 The template is then automatically built and copied in based on this.
 
+## Variants of config file
+
+We currently build two different configs:
+- Raspberry Pi config, named docker.config and uses i2c-1 bus
+- RockPi config, named docker.config.rockpi and uses i2c-7 bus
+
+This is done by passing a ROCKPI=1 env variable to the python command in the GitHub Actions workflow when building the RockPi config.
+
 ## Other Vendors / DIY
 
 For other manufacturers / DIY owners that wish to introduce an "instant sync" feature - you are more than welcome to use our snapshots for this purpose free of charge. We will publish some documentation on this shortly, but basically we have:
@@ -30,7 +38,7 @@ For other manufacturers / DIY owners that wish to introduce an "instant sync" fe
 
 ## Notes
 
-When updating the config.template and txt files in tests/fixtures make sure to remove any new line characters from the end of the file, or the python unit tests will fail.
+When updating the config.template and txt files in tests/fixtures make sure to remove any new line characters from the end of the file, or the python unit tests will fail. You can do this using something like `truncate -s -1 miner_config/tests/fixtures/sample_output.txt`. If on macOS you may need to first `brew install truncate`.
 
 ## References
 

--- a/config.template
+++ b/config.template
@@ -50,7 +50,7 @@
    {blessed_snapshot_block_hash,
      {{blessed_block_hash}}},
    {listen_addresses, ["/ip4/0.0.0.0/tcp/44158"]},
-   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 0}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
+   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 0}, {bus, "{{i2c_bus}}"}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},

--- a/miner_config/generate_config.py
+++ b/miner_config/generate_config.py
@@ -25,6 +25,7 @@ def get_latest_snapshot_block(base_url):
 def populate_template(
         blessed_block,
         base_url,
+        i2c_bus,
         template_file='config.template'
 ):
     template = Template(open(template_file).read())
@@ -32,6 +33,7 @@ def populate_template(
     block_hash = blessed_block['hash']
 
     output = template.render(
+        i2c_bus=i2c_bus,
         base_url=base_url,
         blessed_block=block_id,
         blessed_block_hash=block_hash
@@ -39,7 +41,7 @@ def populate_template(
     return output
 
 
-def output_config_file(config, path='docker.config'):
+def output_config_file(config, path):
     open(path, "w").write(config)
 
 
@@ -49,9 +51,16 @@ def main():
     else:
         base_url = 'https://helium-snapshots-stage.nebra.com'
 
+    if bool(int(os.getenv('ROCKPI', '1'))):
+        i2c_bus = 'i2c-7'
+        path = 'docker.config.rockpi'
+    else:
+        i2c_bus = 'i2c-1'
+        path = 'docker.config'
+
     latest_snapshot = get_latest_snapshot_block(base_url)
-    config = populate_template(latest_snapshot, base_url)
-    output_config_file(config)
+    config = populate_template(latest_snapshot, base_url, i2c_bus)
+    output_config_file(config, path)
 
 
 if __name__ == '__main__':

--- a/miner_config/tests/fixtures/sample_output.txt
+++ b/miner_config/tests/fixtures/sample_output.txt
@@ -50,7 +50,7 @@
    {blessed_snapshot_block_hash,
      HASH HERE},
    {listen_addresses, ["/ip4/0.0.0.0/tcp/44158"]},
-   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 0}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
+   {key, {ecc, [{key_slot, 0}, {onboarding_key_slot, 0}, {bus, "i2c-1"}]}}, %% don't make this the last line in the stanza because sed and keep it on one line
    {base_dir, "/var/data"},
    {onboarding_dir, "/mnt/uboot"},
    {num_consensus_members, 16},

--- a/miner_config/tests/test_generate_config.py
+++ b/miner_config/tests/test_generate_config.py
@@ -36,5 +36,6 @@ class TestPopulateTemplate(TestCase):
             'hash': 'HASH HERE'
         }
         base_url = 'https://helium-snapshots.nebra.com'
-        output = populate_template(blessed_block, base_url)
+        i2c_bus = 'i2c-1'
+        output = populate_template(blessed_block, base_url, i2c_bus)
         self.assertEqual(output, conf_file)


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Support RockPi with custom config template that uses correct i2c bus i2c-7

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- add i2c-bus to config template
- add rockpi env variable for generating different configs
- add logic for populating i2c bus in template
- update staging and production actions workflows to generate docker.config.rockpi and save to storage bucket
- update test fixtures to add new i2c bus parameter
- change test coverage check to 80%
- update unit test to add i2c bus check
- update README to add info about truncate and RockPi

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: NebraLtd/hm-miner#53
Relates-to: NebraLtd/hm-miner#31