### PR TITLE
feat: 6gb snapshop memory limit

### DIFF
--- a/snapshotter/sys.config
+++ b/snapshotter/sys.config
@@ -65,7 +65,8 @@
    {relay_limit, 50},
    {disable_gateway_cache, true},
    {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {gw_context_cache_max_size, 0},
+   {snapshot_memory_limit, 6144}
   ]},
  {relcast,
   [


### PR DESCRIPTION
**Issue**

- Link: https://nebraltd.slack.com/archives/C024BNQ1Y6T/p1645986683626659
- Summary: Snapshotter had fallen behind because of a heap overflow issue and a broken GA. This addresses the heap overflow.

**How**
The server was previously using 4gb memory and logging this error when trying to take a snapshot:

```
    Process:            <8561.2147.0> on node 'miner@127.0.0.1'
     Context:            maximum heap size reached
     Max Heap Size:      26214400
     Total Heap Size:    28235730
```

The server is now running with 16gb of memory and the snapshot size limit has been increased.


**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [x] Documentation added
- [ ] Thought about variable and method names