### PR TITLE
fix: add notification to slack on failure

### DIFF
--- a/.github/workflows/run-update-production.yml
+++ b/.github/workflows/run-update-production.yml
@@ -78,4 +78,29 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \
           --data '{"files":["https://helium-snapshots.nebracdn.com/latest-snap.json",{"url":"https://helium-snapshots.nebracdn.com/latest-snap.json"}]}'
-
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          status: ${{ job.status }}
+          notification_title: 'Production hm-block-tracker config update has failed - please check urgently!'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: '<{run_url}|View Run> | Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
+          mention_groups: 'S02GCFWL27R'
+          notify_when: 'failure'
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.MINER_MONITORING_SLACK }}
+      - name: Report Status Dev Team
+        if: always()
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          status: ${{ job.status }}
+          notification_title: 'Production hm-block-tracker config update has failed - please check urgently!'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: '<{run_url}|View Run> | Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
+          mention_groups: 'S02GCFWL27R'
+          notify_when: 'failure'
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEV_TEAM_SLACK }}

--- a/.github/workflows/run-update-stage.yml
+++ b/.github/workflows/run-update-stage.yml
@@ -76,3 +76,29 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_CACHE_PURGE_KEY }}" \
           -H "Content-Type: application/json" \
           --data '{"files":["https://helium-snapshots-stage.nebracdn.com/latest-snap.json",{"url":"https://helium-snapshots-stage.nebracdn.com/latest-snap.json"}]}'
+      - name: Report Status
+        if: always()
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          status: ${{ job.status }}
+          notification_title: 'Staging hm-block-tracker config update has failed - please check urgently!'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: '<{run_url}|View Run> | Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
+          mention_groups: 'S02GCFWL27R'
+          notify_when: 'failure'
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.MINER_MONITORING_SLACK }}
+      - name: Report Status Dev Team
+        if: always()
+        uses: ravsamhq/notify-slack-action@master
+        with:
+          status: ${{ job.status }}
+          notification_title: 'Staging hm-block-tracker config update has failed - please check urgently!'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: '<{run_url}|View Run> | Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
+          mention_groups: 'S02GCFWL27R'
+          notify_when: 'failure'
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.DEV_TEAM_SLACK }}


### PR DESCRIPTION
**Issue**

- Link: N/A
- Summary: as workflows only run from the master branch, updating a workflow on master updates it. if necessary changes have not yet been merged to production branch this can cause a failure which is not notified for some time.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

add notification on failure to slack channel

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names