### PR TITLE
feat: Incorporate sys.config changes from Helium miner 2022.04.19.0 r…

### DIFF
--- a/config-stage.template
+++ b/config-stage.template
@@ -65,7 +65,8 @@
    {relay_limit, 50},
    {disable_gateway_cache, true},
    {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {gw_context_cache_max_size, 0},
+   {blocks_to_protect_from_gc, 4000}
   ]},
  {relcast,
   [

--- a/config.template
+++ b/config.template
@@ -65,7 +65,8 @@
    {relay_limit, 50},
    {disable_gateway_cache, true},
    {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {gw_context_cache_max_size, 0},
+   {blocks_to_protect_from_gc, 4000}
   ]},
  {relcast,
   [

--- a/miner_config/tests/fixtures/sample_output.txt
+++ b/miner_config/tests/fixtures/sample_output.txt
@@ -65,7 +65,8 @@
    {relay_limit, 50},
    {disable_gateway_cache, true},
    {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {gw_context_cache_max_size, 0},
+   {blocks_to_protect_from_gc, 4000}
   ]},
  {relcast,
   [

--- a/miner_config/tests/fixtures/sample_output_staging.txt
+++ b/miner_config/tests/fixtures/sample_output_staging.txt
@@ -65,7 +65,8 @@
    {relay_limit, 50},
    {disable_gateway_cache, true},
    {gw_cache_retention_limit, 0},
-   {gw_context_cache_max_size, 0}
+   {gw_context_cache_max_size, 0},
+   {blocks_to_protect_from_gc, 4000}
   ]},
  {relcast,
   [


### PR DESCRIPTION
**[Issue](https://github.com/NebraLtd/hm-block-tracker/issues/84)**

- Link:https://github.com/NebraLtd/hm-block-tracker/issues/84
- Summary: Helium miner 2022.04.19.0 release has light miner built into it (disabled state). There are new variables in the upstream sys.config that needs to incorporated into our cdn sys.config

**How**
* bring back "blocks_to_protect_from_gc" variable

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names