### PR TITLE
feat: save snapshot with .gz extension

### DIFF
--- a/snapshotter/create_snapshot.sh
+++ b/snapshotter/create_snapshot.sh
@@ -51,7 +51,7 @@ done
 
 # Only upload snapshots if they are all valid.
 if [ "$ARE_SNAPSHOTS_VALID" -eq "1" ]; then
-    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT"
+    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT.gz"
     gsutil cp "$TMPDIR/latest.json" "gs://$SNAPSHOT_BUCKET/latest.json"
     gsutil cp "$TMPDIR/latest-snap.json" "gs://$SNAPSHOT_BUCKET/latest-snap.json"
 fi


### PR DESCRIPTION
**Issue**

- Link: https://nebraltd.slack.com/archives/C024BNQ1Y6T/p1652393225618449
- Summary: Snapshot loading is broken on miners and we think its because of a change in expected filetype.

**How**
Snapshot loading now expecting this extension.
We think this will work even if the file is not actually compressed.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names