### PR TITLE
Switch to compressed archives

### DIFF
--- a/snapshotter/create_snapshot.sh
+++ b/snapshotter/create_snapshot.sh
@@ -27,15 +27,15 @@ fi
 
 
 # Initial sanity checks passed. Continuing on with a snapshot.
-docker exec miner miner snapshot take /var/data/saved-snaps/latest
-BLOCK_HEIGHT=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | head -1 | awk {'print $2'})
-BLOCK_HASH_PART1=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | tail -3 | head -1 | awk {'print $2'})
-BLOCK_HASH_PART2=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | tail -2 | head -1 | awk {'print $1'})
+docker exec miner miner snapshot take /var/data/saved-snaps/latest.gz
+BLOCK_HEIGHT=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | head -1 | awk {'print $2'})
+BLOCK_HASH_PART1=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | tail -3 | head -1 | awk {'print $2'})
+BLOCK_HASH_PART2=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | tail -2 | head -1 | awk {'print $1'})
 BYTE_ARRAY="${BLOCK_HASH_PART1}${BLOCK_HASH_PART2}"
 BASE64URL_FORMAT=$(python3 /home/snapshot/hm-block-tracker/snapshotter/base64url_encoder.py "$BYTE_ARRAY")
 TMPDIR=$(mktemp -d)
 
-mv /var/miner_data/saved-snaps/latest "$TMPDIR/snap-$BLOCK_HEIGHT"
+mv /var/miner_data/saved-snaps/latest.gz "$TMPDIR/snap-$BLOCK_HEIGHT.gz"
 echo "{\"height\": $BLOCK_HEIGHT, \"hash\": \"$BYTE_ARRAY\"}" | tee -a "$TMPDIR/latest.json"
 echo "{\"height\": $BLOCK_HEIGHT, \"hash\": \"$BASE64URL_FORMAT\"}" | tee -a "$TMPDIR/latest-snap.json"
 
@@ -51,7 +51,7 @@ done
 
 # Only upload snapshots if they are all valid.
 if [ "$ARE_SNAPSHOTS_VALID" -eq "1" ]; then
-    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT"
+    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT.gz" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT.gz"
     gsutil cp "$TMPDIR/latest.json" "gs://$SNAPSHOT_BUCKET/latest.json"
     gsutil cp "$TMPDIR/latest-snap.json" "gs://$SNAPSHOT_BUCKET/latest-snap.json"
 fi


### PR DESCRIPTION
**Issue**
With the latest updates, miner seem to be defaulting to loading compressed snapshots.
Hence generate and publish compressed.



**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names