### PR TITLE
fix: ignore snapshot timeouts

### DIFF
--- a/snapshotter/create_snapshot.sh
+++ b/snapshotter/create_snapshot.sh
@@ -28,21 +28,22 @@ fi
 
 # Initial sanity checks passed. Continuing on with a snapshot.
 echo "About to take snapshot"
-docker exec miner miner snapshot take /var/data/saved-snaps/latest
+# Sometimes the snapshot times out and needs more time to finish
+docker exec miner miner snapshot take /var/data/saved-snaps/latest || (echo "Snapshot still loading, sleeping..." && sleep 60)
 
 echo "Parsing snapshot (1/3)"
-BLOCK_HEIGHT=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | head -1 | awk {'print $2'})
+BLOCK_HEIGHT=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | head -1 | awk {'print $2'})
 
 echo "Parsing snapshot (2/3)"
-BLOCK_HASH_PART1=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | tail -3 | head -1 | awk {'print $2'})
+BLOCK_HASH_PART1=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | tail -3 | head -1 | awk {'print $2'})
 
 echo "Parsing snapshot (3/3)"
-BLOCK_HASH_PART2=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest | tail -2 | head -1 | awk {'print $1'})
+BLOCK_HASH_PART2=$(docker exec miner miner snapshot info /var/data/saved-snaps/latest.gz | tail -2 | head -1 | awk {'print $1'})
 BYTE_ARRAY="${BLOCK_HASH_PART1}${BLOCK_HASH_PART2}"
 BASE64URL_FORMAT=$(python3 /home/snapshot/hm-block-tracker/snapshotter/base64url_encoder.py "$BYTE_ARRAY")
 TMPDIR=$(mktemp -d)
 
-mv /var/miner_data/saved-snaps/latest "$TMPDIR/snap-$BLOCK_HEIGHT"
+mv /var/miner_data/saved-snaps/latest.gz "$TMPDIR/snap-$BLOCK_HEIGHT.gz"
 echo "{\"height\": $BLOCK_HEIGHT, \"hash\": \"$BYTE_ARRAY\"}" | tee -a "$TMPDIR/latest.json"
 echo "{\"height\": $BLOCK_HEIGHT, \"hash\": \"$BASE64URL_FORMAT\"}" | tee -a "$TMPDIR/latest-snap.json"
 
@@ -60,7 +61,7 @@ done
 # Only upload snapshots if they are all valid.
 if [ "$ARE_SNAPSHOTS_VALID" -eq "1" ]; then
     echo "Copying snapshot to GCS"
-    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT.gz"
+    gsutil cp "$TMPDIR/snap-$BLOCK_HEIGHT.gz" "gs://$SNAPSHOT_BUCKET/snap-$BLOCK_HEIGHT.gz"
     gsutil cp "$TMPDIR/latest.json" "gs://$SNAPSHOT_BUCKET/latest.json"
     gsutil cp "$TMPDIR/latest-snap.json" "gs://$SNAPSHOT_BUCKET/latest-snap.json"
 fi


### PR DESCRIPTION
Should be merged after: https://github.com/NebraLtd/hm-block-tracker/pull/95

**Issue**

- Link: https://github.com/NebraLtd/hm-block-tracker/issues/96
- Summary: Ignore snapshot timeouts that are not terminal.

**How**
`miner snapshot take` is terminating early every time the snapshotter runs.
> RPC to 'miner@127.0.0.1' failed: timeout
    
This does not appear to be a terminal error, and snapshots are still generated. Because the script exits on error, an OR statement is used to silence this error and sleep to let the snapshot finish.


**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names