### PR TITLE
update: snapshotter config for GA 2022.06.09.0

### DIFF
--- a/snapshotter/sys.config
+++ b/snapshotter/sys.config
@@ -106,7 +106,7 @@
    {jsonrpc_ip, {127,0,0,1}}, %% bind JSONRPC to localhost only
    {jsonrpc_port, 4467},
    {mode, gateway},
-   {gateway_and_mux_enable, false},
+   {gateway_and_mux_enable, true},
    {gateways_run_chain, true}, %% if false, gateways will no longer follow the chain
    {use_ebus, true},
    {batch_size, 2500},


### PR DESCRIPTION
**Issue**

- Link:
- Summary: Enable mux for snapshotter. Configs for miners in fleet have already been updated

**How**
https://engineering.helium.com/2022/06/10/miner-hotspot-release.html

**Screenshots**
<!-- Include images, if possible. -->

**References**
Follow-up to: https://github.com/NebraLtd/hm-block-tracker/pull/102/files

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names