### PR TITLE
Allow invalid latest-snap.json previously uploaded

### DIFF
--- a/snapshotter/create_snapshot.sh
+++ b/snapshotter/create_snapshot.sh
@@ -13,7 +13,7 @@ fi
 
 # Let's first start by sanity checking that the miner works as expected
 CURRENT_MINER_HEIGHT=$(docker exec miner miner info height | awk {'print $2'})
-CURRENT_SNAPSHOT_HEIGHT=$(curl -s https://$SNAPSHOT_BUCKET/latest-snap.json | jq .height)
+CURRENT_SNAPSHOT_HEIGHT=$(curl -s https://$SNAPSHOT_BUCKET/latest-snap.json | jq .height &2>/dev/null)
 if [[ "failed" == *"$CURRENT_MINER_HEIGHT"* ]]; then
     echo "Got error from miner. Restarting miner and exiting."
     docker restart miner


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/product-management/issues/70#issuecomment-1158447023
- Summary:
Before taking the snapshot, 'create_snapshot.sh` try to get the height from the previously uploaded `latest-snap.json` file.
If it's invalid, taking the snapshot just fails.
We need to allow taking the snapshot even if the previously uploaded `latest-snap.json` is invalid.

**How**
Sliencing the `jq` error while extracting the `height` field from `latest-snap.json` since it might be invalid.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names