### PR TITLE
Fix config key slot

### DIFF
--- a/miner_config/generate_config.py
+++ b/miner_config/generate_config.py
@@ -110,7 +110,7 @@ def main():
     i2c_bus = parse_result.hostname
     i2c_address = parse_i2c_address(parse_result.port)
     query_string = parse_qs(parse_result.query)
-    key_slot = query_string["slot"]
+    key_slot = query_string["slot"][0]
 
     latest_snapshot = get_latest_snapshot_block(base_url)
     config = populate_template(latest_snapshot, base_url, i2c_bus, key_slot,


### PR DESCRIPTION
**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

As per https://docs.python.org/3/library/urllib.parse.html

> The dictionary keys are the unique query variable names and the values are lists of values for each name.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names